### PR TITLE
docs(recoverer): reviewed by fnanni-0

### DIFF
--- a/contracts/BalancerPoolRecoverer.sol
+++ b/contracts/BalancerPoolRecoverer.sol
@@ -1,6 +1,6 @@
 /**
  * @authors: [@nix1g]
- * @reviewers: [@clesaege*, @ferittuncer, @fnanni-0*, @mtsalenc, @unknownunknown1]
+ * @reviewers: [@clesaege*, @ferittuncer, @fnanni-0, @mtsalenc, @unknownunknown1]
  * @auditors: []
  * @bounties: []
  * @deployments: []


### PR DESCRIPTION
@nix1g Looks good to me!

The only thing I have to mention is that all the immutable variables assigned in the constructor could be as well constants if we know those addresses beforehand. Any reason in particular why we set them in the constructor?